### PR TITLE
Improving this awesome project

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -126,7 +126,7 @@ Style/Documentation:
   Enabled: false
 
 # This is just silly. Calling the argument `other` in all cases makes no sense.
-Style/OpMethod:
+Naming/BinaryOperatorParameter:
   Enabled: false
 
 # There are valid cases, for example debugging Cucumber steps,

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,10 @@ build:
 	docker build -t mr .
 
 run: build
-	docker run --rm -v `pwd`:/app/ -it mr ruby lib/main.rb
+	docker run --rm -v "$(shell pwd):/app/" -it mr ruby lib/main.rb
 
 test: build
-	docker run --rm -v `pwd`:/app/ -it mr rspec
+	docker run --rm -v "$(shell pwd):/app/" -it mr rspec
 
 lint: build
-	docker run --rm -v `pwd`:/app/ -it mr rubocop
+	docker run --rm -v "$(shell pwd):/app/" -it mr rubocop

--- a/lib/main.rb
+++ b/lib/main.rb
@@ -1,5 +1,5 @@
 require_relative "helloworld.rb"
 
-helloWorld = HelloWorld.new
+hello_world = HelloWorld.new
 
-puts helloWorld.execute
+puts hello_world.execute

--- a/spec/helloworld_spec.rb
+++ b/spec/helloworld_spec.rb
@@ -3,13 +3,12 @@ require_relative "spec_helper.rb"
 describe HelloWorld do
   it "returns Hello World" do
     # arrange (setup)
-    helloWorld = HelloWorld.new
+    hello_world = HelloWorld.new
 
     # act (perform)
-    result = helloWorld.execute
+    result = hello_world.execute
 
     # assert (assertion)
     expect(result).to eq("Hello World")
   end
-
 end


### PR DESCRIPTION
7487448 - If the project path had spaces in its name, the `cmd` would fail.
8217a18 - Ruby doesn't use camel case, uses snake case instead
033325d - 'Style/OpMethods' cop has been renamed and moved to 'Naming/BinaryOperatorParameter'